### PR TITLE
Update LTS 8.17

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: nightly-2016-10-28
+resolver: lts-8.17


### PR DESCRIPTION
We should consider removing the dependency of this library and use the [base library](https://github.com/jpvillaisaza/mailchimp-haskell) instead. For now, this will allow us to use it with latest lts from stackage.

I've already built the library and everything is properly working. (we don't have CI for this fork)